### PR TITLE
Adding sort function to slice maps

### DIFF
--- a/pkg/maps/safeslicemap.go
+++ b/pkg/maps/safeslicemap.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"encoding/json"
+	"sort"
 	"strings"
     "sync"
 
@@ -23,6 +24,7 @@ type SafeSliceMap struct {
     sync.RWMutex
 	items map[string]interface{}
 	order []string
+	lessF func(key1,key2 string, val1, val2 interface{}) bool
 }
 
 // NewSafeSliceMap creates a new map that maps string's to interface{}'s.
@@ -53,12 +55,36 @@ func NewSafeSliceMapFromMap(i map[string]interface{}) *SafeSliceMap {
 	return m
 }
 
+// SetSortFunc sets the sort function which will determine the order of the items in the map
+// on an ongoing basis. Normally, items will iterate in the order they were added.
+// The sort function is a Less function, that returns true when item 1 is "less" than item 2.
+// The sort function receives both the keys and values, so it can use either to decide how to sort.
+func (o *SafeSliceMap) SetSortFunc(f func(key1,key2 string, val1, val2 interface{}) bool) {
+        o.Lock()
+    o.lessF = f
+    if f != nil && len(o.order) > 0 {
+        sort.Slice(o.order, func(i,j int) bool {
+            return f(o.order[i], o.order[j], o.items[o.order[i]], o.items[o.order[j]])
+        })
+    }
+        o.Unlock()
+}
 
+// SortByKeys sets up the map to have its sort order sort by keys, lowest to highest
+func (o *SafeSliceMap) SortByKeys() {
+    o.SetSortFunc(keySortSafeSliceMap)
+}
 
-// SetChanged sets the value, but also appends the value to the end of the list.
+func keySortSafeSliceMap(key1, key2 string, val1, val2 interface{}) bool {
+    return key1 < key2
+}
+
+// SetChanged sets the value.
 // It returns true if something in the map changed. If the key
-// was already in the map, the order will not change, but the value will be replaced. If you want the
-// order to change, you must Delete then call SetChanged.
+// was already in the map, and you have not provided a sort function,
+// the order will not change, but the value will be replaced. If you wanted the
+// order to change, you must Delete then call SetChanged. If you have previously set a sort function,
+// the order will be updated.
 func (o *SafeSliceMap) SetChanged(key string, val interface{}) (changed bool) {
 	var ok bool
 	var oldVal interface{}
@@ -73,8 +99,25 @@ func (o *SafeSliceMap) SetChanged(key string, val interface{}) (changed bool) {
 	}
 
 	if oldVal, ok = o.items[key]; !ok || oldVal != val {
-		if !ok {
-			o.order = append(o.order, key)
+        if o.lessF != nil {
+            if ok {
+                // delete old key location
+                loc := sort.Search (len(o.items), func(n int) bool {
+                    return o.lessF(key, o.order[n], oldVal, o.items[o.order[n]])
+                })
+                o.order = append(o.order[:loc], o.order[loc+1:]...)
+            }
+
+            loc := sort.Search (len(o.items), func(n int) bool {
+                return o.lessF(key, o.order[n], val, o.items[o.order[n]])
+            })
+            o.order = append(o.order, key)
+            copy(o.order[loc+1:], o.order[loc:])
+            o.order[loc] = key
+        } else {
+		    if !ok {
+			    o.order = append(o.order, key)
+		    }
 		}
 		o.items[key] = val
 		changed = true
@@ -91,14 +134,17 @@ func (o *SafeSliceMap) Set(key string, val interface{}) {
 }
 
 // SetAt sets the given key to the given value, but also inserts it at the index specified.  If the index is bigger than
-// the length, or -1, it is the same as Set, in that it puts it at the end. Negative indexes are backwards from the
-// end, if smaller than the negative length, just inserts at the beginning.
+// the length, it puts it at the end. Negative indexes are backwards from the end.
 func (o *SafeSliceMap) SetAt(index int, key string, val interface{})  {
     if o == nil {
         panic("You must initialize the map before using it.")
     }
 
-	if index == -1 || index >= len(o.order) {
+    if o.lessF != nil {
+        panic("You cannot use SetAt if you are also using a sort function.")
+    }
+
+	if index >= len(o.order) {
 		o.Set(key, val)
 		return
 	}
@@ -108,11 +154,11 @@ func (o *SafeSliceMap) SetAt(index int, key string, val interface{})  {
     o.Lock()
 
 	if _, ok = o.items[key]; !ok {
-		if index < -len(o.items) {
+		if index <= -len(o.items) {
 			index = 0
 		}
 		if index < 0 {
-			index = len(o.items) + index + 1
+			index = len(o.items) + index
 		}
 
 		o.order = append(o.order, emptyKey)
@@ -130,13 +176,24 @@ func (o *SafeSliceMap) Delete(key string) {
         return
     }
     o.Lock()
-	for i, v := range o.order {
-		if v == key {
-			o.order = append(o.order[:i], o.order[i+1:]...)
-			break
-		}
-	}
-	delete(o.items, key)
+
+    if _,ok := o.items[key]; ok {
+        if o.lessF != nil {
+            oldVal := o.items[key]
+            loc := sort.Search (len(o.items), func(n int) bool {
+                return o.lessF(key, o.order[n], oldVal, o.items[o.order[n]])
+            })
+            o.order = append(o.order[:loc], o.order[loc+1:]...)
+        } else {
+            for i, v := range o.order {
+                if v == key {
+                    o.order = append(o.order[:i], o.order[i+1:]...)
+                    break
+                }
+            }
+        }
+        delete(o.items, key)
+    }
     o.Unlock()
 }
 
@@ -284,26 +341,6 @@ func (o *SafeSliceMap) Len() int {
 	return l
 }
 
-// Less is part of the interface that allows the map to be sorted by keys.
-// It returns true if the value at position i should be sorted before the value at position j.
-func (o *SafeSliceMap) Less(i, j int) bool {
-
-	o.RLock()
-	defer o.RUnlock()
-
-	return o.order[i] < o.order[j]
-
-}
-
-// Swap is part of the interface that allows the slice to be sorted. It swaps the positions
-// of the items and position i and j.
-func (o *SafeSliceMap) Swap(i, j int) {
-	o.Lock()
-	o.order[i], o.order[j] = o.order[j], o.order[i]
-    o.Unlock()
-}
-
- 
 
 // Copy will make a copy of the map and a copy of the underlying data.
 func (o *SafeSliceMap) Copy() *SafeSliceMap {
@@ -318,6 +355,8 @@ func (o *SafeSliceMap) Copy() *SafeSliceMap {
 }
 
 // MarshalBinary implements the BinaryMarshaler interface to convert the map to a byte stream.
+// If you are using a sort function, you must save and restore the sort function in a separate operation
+// since functions are not serializable.
 func (o *SafeSliceMap) MarshalBinary() (data []byte, err error) {
 	buf := new(bytes.Buffer)
 	encoder := gob.NewEncoder(buf)

--- a/pkg/maps/safeslicemap_test.go
+++ b/pkg/maps/safeslicemap_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"sort"
 )
 
 func TestSafeSliceMap(t *testing.T) {
@@ -106,7 +105,7 @@ func ExampleSafeSliceMap_Range() {
 
 
 	// Iterate after sorting keys
-	sort.Sort(m)
+	m.SortByKeys()
 	m.Range(func(key string, val interface{}) bool {
 		fmt.Printf("%s:%s,", key, val)
 		return true // keep iterating to the end
@@ -161,7 +160,7 @@ func ExampleSafeSliceMap_UnmarshalJSON() {
 	var m SafeSliceMap
 
 	json.Unmarshal(b, &m)
-	sort.Sort(&m)
+	m.SortByKeys()
 	fmt.Println(&m)
 
 	// Output: {"A":"That","B":"This","C":"Other"}
@@ -238,7 +237,7 @@ func TestSafeSliceMap_SetAt(t *testing.T) {
 	    t.Errorf("Middle insert failed. Expected C and got %s", m.GetAt(1))
 	}
 
-	m.SetAt(-2, "d", "D")
+	m.SetAt(-1, "d", "D")
     if "D" != m.GetAt(2) {
         t.Errorf("Middle insert failed. Expected D and got %s", m.GetAt(2))
     }
@@ -247,7 +246,7 @@ func TestSafeSliceMap_SetAt(t *testing.T) {
     }
 
 	// Test end inserts
-	m.SetAt(-1, "e", "E")
+	m.SetAt(m.Len(), "e", "E")
 	m.SetAt(1000, "f", "F")
     if "E" != m.GetAt(4) {
         t.Errorf("End insert failed. Expected E and got %s", m.GetAt(4))

--- a/pkg/maps/safestrslicemap_test.go
+++ b/pkg/maps/safestrslicemap_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"sort"
 	"testing"
 )
 
@@ -44,12 +43,6 @@ func TestSafeStringSliceMap(t *testing.T) {
 	if s != "This+That+Other" {
 		t.Error("Failed Join.")
 	}
-
-    // Test that it satisfies the Sort interface
-    sort.Sort(m)
-    if s = m.GetAt(0); s != "That" {
-        t.Error("Sort interface test failed.")
-    }
 
 	m.Delete("A")
 
@@ -117,7 +110,10 @@ func ExampleSafeStringSliceMap_Range() {
 	fmt.Println()
 
 	// Iterate after sorting values
-	sort.Sort(OrderSafeStringSliceMapByValues(m))
+    m.SetSortFunc(func(key1, key2 string, val1, val2 string) bool {
+        return val1 < val2
+    })
+
 	m.Range(func(key string, val string) bool {
 		fmt.Printf("%s:%s,", key, val)
 		return true // keep iterating to the end
@@ -125,7 +121,9 @@ func ExampleSafeStringSliceMap_Range() {
 	fmt.Println()
 
 	// Iterate after sorting keys
-	sort.Sort(m)
+    m.SetSortFunc(func(key1, key2 string, val1, val2 string) bool {
+        return key1 < key2
+    })
 	m.Range(func(key string, val string) bool {
 		fmt.Printf("%s:%s,", key, val)
 		return true // keep iterating to the end
@@ -181,7 +179,7 @@ func ExampleSafeStringSliceMap_UnmarshalJSON() {
 	var m SafeStringSliceMap
 
 	json.Unmarshal(b, &m)
-	sort.Sort(&m)
+	m.SortByKeys()
 
 	fmt.Println(&m)
 
@@ -259,7 +257,7 @@ func TestSafeStringSliceMap_SetAt(t *testing.T) {
 	    t.Errorf("Middle insert failed. Expected C and got %s", m.GetAt(1))
 	}
 
-	m.SetAt(-2, "d", "D")
+	m.SetAt(-1, "d", "D")
     if "D" != m.GetAt(2) {
         t.Errorf("Middle insert failed. Expected D and got %s", m.GetAt(2))
     }
@@ -268,7 +266,7 @@ func TestSafeStringSliceMap_SetAt(t *testing.T) {
     }
 
 	// Test end inserts
-	m.SetAt(-1, "e", "E")
+	m.SetAt(m.Len(), "e", "E")
 	m.SetAt(1000, "f", "F")
     if "E" != m.GetAt(4) {
         t.Errorf("End insert failed. Expected E and got %s", m.GetAt(4))

--- a/pkg/maps/slicemap.go
+++ b/pkg/maps/slicemap.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"encoding/json"
+	"sort"
 	"strings"
 
 	"fmt"
@@ -21,6 +22,7 @@ import (
 type SliceMap struct {
 	items map[string]interface{}
 	order []string
+	lessF func(key1,key2 string, val1, val2 interface{}) bool
 }
 
 // NewSliceMap creates a new map that maps string's to interface{}'s.
@@ -51,12 +53,34 @@ func NewSliceMapFromMap(i map[string]interface{}) *SliceMap {
 	return m
 }
 
+// SetSortFunc sets the sort function which will determine the order of the items in the map
+// on an ongoing basis. Normally, items will iterate in the order they were added.
+// The sort function is a Less function, that returns true when item 1 is "less" than item 2.
+// The sort function receives both the keys and values, so it can use either to decide how to sort.
+func (o *SliceMap) SetSortFunc(f func(key1,key2 string, val1, val2 interface{}) bool) {
+    o.lessF = f
+    if f != nil && len(o.order) > 0 {
+        sort.Slice(o.order, func(i,j int) bool {
+            return f(o.order[i], o.order[j], o.items[o.order[i]], o.items[o.order[j]])
+        })
+    }
+}
 
+// SortByKeys sets up the map to have its sort order sort by keys, lowest to highest
+func (o *SliceMap) SortByKeys() {
+    o.SetSortFunc(keySortSliceMap)
+}
 
-// SetChanged sets the value, but also appends the value to the end of the list.
+func keySortSliceMap(key1, key2 string, val1, val2 interface{}) bool {
+    return key1 < key2
+}
+
+// SetChanged sets the value.
 // It returns true if something in the map changed. If the key
-// was already in the map, the order will not change, but the value will be replaced. If you want the
-// order to change, you must Delete then call SetChanged.
+// was already in the map, and you have not provided a sort function,
+// the order will not change, but the value will be replaced. If you wanted the
+// order to change, you must Delete then call SetChanged. If you have previously set a sort function,
+// the order will be updated.
 func (o *SliceMap) SetChanged(key string, val interface{}) (changed bool) {
 	var ok bool
 	var oldVal interface{}
@@ -70,8 +94,25 @@ func (o *SliceMap) SetChanged(key string, val interface{}) (changed bool) {
 	}
 
 	if oldVal, ok = o.items[key]; !ok || oldVal != val {
-		if !ok {
-			o.order = append(o.order, key)
+        if o.lessF != nil {
+            if ok {
+                // delete old key location
+                loc := sort.Search (len(o.items), func(n int) bool {
+                    return o.lessF(key, o.order[n], oldVal, o.items[o.order[n]])
+                })
+                o.order = append(o.order[:loc], o.order[loc+1:]...)
+            }
+
+            loc := sort.Search (len(o.items), func(n int) bool {
+                return o.lessF(key, o.order[n], val, o.items[o.order[n]])
+            })
+            o.order = append(o.order, key)
+            copy(o.order[loc+1:], o.order[loc:])
+            o.order[loc] = key
+        } else {
+		    if !ok {
+			    o.order = append(o.order, key)
+		    }
 		}
 		o.items[key] = val
 		changed = true
@@ -87,14 +128,17 @@ func (o *SliceMap) Set(key string, val interface{}) {
 }
 
 // SetAt sets the given key to the given value, but also inserts it at the index specified.  If the index is bigger than
-// the length, or -1, it is the same as Set, in that it puts it at the end. Negative indexes are backwards from the
-// end, if smaller than the negative length, just inserts at the beginning.
+// the length, it puts it at the end. Negative indexes are backwards from the end.
 func (o *SliceMap) SetAt(index int, key string, val interface{})  {
     if o == nil {
         panic("You must initialize the map before using it.")
     }
 
-	if index == -1 || index >= len(o.order) {
+    if o.lessF != nil {
+        panic("You cannot use SetAt if you are also using a sort function.")
+    }
+
+	if index >= len(o.order) {
 		o.Set(key, val)
 		return
 	}
@@ -103,11 +147,11 @@ func (o *SliceMap) SetAt(index int, key string, val interface{})  {
 	var emptyKey string
 
 	if _, ok = o.items[key]; !ok {
-		if index < -len(o.items) {
+		if index <= -len(o.items) {
 			index = 0
 		}
 		if index < 0 {
-			index = len(o.items) + index + 1
+			index = len(o.items) + index
 		}
 
 		o.order = append(o.order, emptyKey)
@@ -123,13 +167,24 @@ func (o *SliceMap) Delete(key string) {
     if o == nil {
         return
     }
-	for i, v := range o.order {
-		if v == key {
-			o.order = append(o.order[:i], o.order[i+1:]...)
-			break
-		}
-	}
-	delete(o.items, key)
+
+    if _,ok := o.items[key]; ok {
+        if o.lessF != nil {
+            oldVal := o.items[key]
+            loc := sort.Search (len(o.items), func(n int) bool {
+                return o.lessF(key, o.order[n], oldVal, o.items[o.order[n]])
+            })
+            o.order = append(o.order[:loc], o.order[loc+1:]...)
+        } else {
+            for i, v := range o.order {
+                if v == key {
+                    o.order = append(o.order[:i], o.order[i+1:]...)
+                    break
+                }
+            }
+        }
+        delete(o.items, key)
+    }
 }
 
 // Get returns the value based on its key. If the key does not exist, an empty value is returned.
@@ -262,22 +317,6 @@ func (o *SliceMap) Len() int {
 	return l
 }
 
-// Less is part of the interface that allows the map to be sorted by keys.
-// It returns true if the value at position i should be sorted before the value at position j.
-func (o *SliceMap) Less(i, j int) bool {
-
-
-	return o.order[i] < o.order[j]
-
-}
-
-// Swap is part of the interface that allows the slice to be sorted. It swaps the positions
-// of the items and position i and j.
-func (o *SliceMap) Swap(i, j int) {
-	o.order[i], o.order[j] = o.order[j], o.order[i]
-}
-
- 
 
 // Copy will make a copy of the map and a copy of the underlying data.
 func (o *SliceMap) Copy() *SliceMap {
@@ -292,6 +331,8 @@ func (o *SliceMap) Copy() *SliceMap {
 }
 
 // MarshalBinary implements the BinaryMarshaler interface to convert the map to a byte stream.
+// If you are using a sort function, you must save and restore the sort function in a separate operation
+// since functions are not serializable.
 func (o *SliceMap) MarshalBinary() (data []byte, err error) {
 	buf := new(bytes.Buffer)
 	encoder := gob.NewEncoder(buf)

--- a/pkg/maps/slicemap_test.go
+++ b/pkg/maps/slicemap_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"sort"
 )
 
 func TestSliceMap(t *testing.T) {
@@ -106,7 +105,7 @@ func ExampleSliceMap_Range() {
 
 
 	// Iterate after sorting keys
-	sort.Sort(m)
+	m.SortByKeys()
 	m.Range(func(key string, val interface{}) bool {
 		fmt.Printf("%s:%s,", key, val)
 		return true // keep iterating to the end
@@ -161,7 +160,7 @@ func ExampleSliceMap_UnmarshalJSON() {
 	var m SliceMap
 
 	json.Unmarshal(b, &m)
-	sort.Sort(&m)
+	m.SortByKeys()
 	fmt.Println(&m)
 
 	// Output: {"A":"That","B":"This","C":"Other"}
@@ -238,7 +237,7 @@ func TestSliceMap_SetAt(t *testing.T) {
 	    t.Errorf("Middle insert failed. Expected C and got %s", m.GetAt(1))
 	}
 
-	m.SetAt(-2, "d", "D")
+	m.SetAt(-1, "d", "D")
     if "D" != m.GetAt(2) {
         t.Errorf("Middle insert failed. Expected D and got %s", m.GetAt(2))
     }
@@ -247,7 +246,7 @@ func TestSliceMap_SetAt(t *testing.T) {
     }
 
 	// Test end inserts
-	m.SetAt(-1, "e", "E")
+	m.SetAt(m.Len(), "e", "E")
 	m.SetAt(1000, "f", "F")
     if "E" != m.GetAt(4) {
         t.Errorf("End insert failed. Expected E and got %s", m.GetAt(4))

--- a/pkg/maps/strslicemap.go
+++ b/pkg/maps/strslicemap.go
@@ -20,6 +20,7 @@ import (
 type StringSliceMap struct {
 	items map[string]string
 	order []string
+	lessF func(key1,key2 string, val1, val2 string) bool
 }
 
 // NewStringSliceMap creates a new map that maps string's to string's.
@@ -50,12 +51,34 @@ func NewStringSliceMapFromMap(i map[string]string) *StringSliceMap {
 	return m
 }
 
+// SetSortFunc sets the sort function which will determine the order of the items in the map
+// on an ongoing basis. Normally, items will iterate in the order they were added.
+// The sort function is a Less function, that returns true when item 1 is "less" than item 2.
+// The sort function receives both the keys and values, so it can use either to decide how to sort.
+func (o *StringSliceMap) SetSortFunc(f func(key1,key2 string, val1, val2 string) bool) {
+    o.lessF = f
+    if f != nil && len(o.order) > 0 {
+        sort.Slice(o.order, func(i,j int) bool {
+            return f(o.order[i], o.order[j], o.items[o.order[i]], o.items[o.order[j]])
+        })
+    }
+}
 
+// SortByKeys sets up the map to have its sort order sort by keys, lowest to highest
+func (o *StringSliceMap) SortByKeys() {
+    o.SetSortFunc(keySortStringSliceMap)
+}
 
-// SetChanged sets the value, but also appends the value to the end of the list.
+func keySortStringSliceMap(key1, key2 string, val1, val2 string) bool {
+    return key1 < key2
+}
+
+// SetChanged sets the value.
 // It returns true if something in the map changed. If the key
-// was already in the map, the order will not change, but the value will be replaced. If you want the
-// order to change, you must Delete then call SetChanged.
+// was already in the map, and you have not provided a sort function,
+// the order will not change, but the value will be replaced. If you wanted the
+// order to change, you must Delete then call SetChanged. If you have previously set a sort function,
+// the order will be updated.
 func (o *StringSliceMap) SetChanged(key string, val string) (changed bool) {
 	var ok bool
 	var oldVal string
@@ -69,8 +92,25 @@ func (o *StringSliceMap) SetChanged(key string, val string) (changed bool) {
 	}
 
 	if oldVal, ok = o.items[key]; !ok || oldVal != val {
-		if !ok {
-			o.order = append(o.order, key)
+        if o.lessF != nil {
+            if ok {
+                // delete old key location
+                loc := sort.Search (len(o.items), func(n int) bool {
+                    return o.lessF(key, o.order[n], oldVal, o.items[o.order[n]])
+                })
+                o.order = append(o.order[:loc], o.order[loc+1:]...)
+            }
+
+            loc := sort.Search (len(o.items), func(n int) bool {
+                return o.lessF(key, o.order[n], val, o.items[o.order[n]])
+            })
+            o.order = append(o.order, key)
+            copy(o.order[loc+1:], o.order[loc:])
+            o.order[loc] = key
+        } else {
+		    if !ok {
+			    o.order = append(o.order, key)
+		    }
 		}
 		o.items[key] = val
 		changed = true
@@ -86,14 +126,17 @@ func (o *StringSliceMap) Set(key string, val string) {
 }
 
 // SetAt sets the given key to the given value, but also inserts it at the index specified.  If the index is bigger than
-// the length, or -1, it is the same as Set, in that it puts it at the end. Negative indexes are backwards from the
-// end, if smaller than the negative length, just inserts at the beginning.
+// the length, it puts it at the end. Negative indexes are backwards from the end.
 func (o *StringSliceMap) SetAt(index int, key string, val string)  {
     if o == nil {
         panic("You must initialize the map before using it.")
     }
 
-	if index == -1 || index >= len(o.order) {
+    if o.lessF != nil {
+        panic("You cannot use SetAt if you are also using a sort function.")
+    }
+
+	if index >= len(o.order) {
 		o.Set(key, val)
 		return
 	}
@@ -102,11 +145,11 @@ func (o *StringSliceMap) SetAt(index int, key string, val string)  {
 	var emptyKey string
 
 	if _, ok = o.items[key]; !ok {
-		if index < -len(o.items) {
+		if index <= -len(o.items) {
 			index = 0
 		}
 		if index < 0 {
-			index = len(o.items) + index + 1
+			index = len(o.items) + index
 		}
 
 		o.order = append(o.order, emptyKey)
@@ -122,13 +165,24 @@ func (o *StringSliceMap) Delete(key string) {
     if o == nil {
         return
     }
-	for i, v := range o.order {
-		if v == key {
-			o.order = append(o.order[:i], o.order[i+1:]...)
-			break
-		}
-	}
-	delete(o.items, key)
+
+    if _,ok := o.items[key]; ok {
+        if o.lessF != nil {
+            oldVal := o.items[key]
+            loc := sort.Search (len(o.items), func(n int) bool {
+                return o.lessF(key, o.order[n], oldVal, o.items[o.order[n]])
+            })
+            o.order = append(o.order[:loc], o.order[loc+1:]...)
+        } else {
+            for i, v := range o.order {
+                if v == key {
+                    o.order = append(o.order[:i], o.order[i+1:]...)
+                    break
+                }
+            }
+        }
+        delete(o.items, key)
+    }
 }
 
 // Get returns the value based on its key. If the key does not exist, an empty value is returned.
@@ -225,48 +279,6 @@ func (o *StringSliceMap) Len() int {
 	return l
 }
 
-// Less is part of the interface that allows the map to be sorted by keys.
-// It returns true if the value at position i should be sorted before the value at position j.
-func (o *StringSliceMap) Less(i, j int) bool {
-
-
-	return o.order[i] < o.order[j]
-
-}
-
-// Swap is part of the interface that allows the slice to be sorted. It swaps the positions
-// of the items and position i and j.
-func (o *StringSliceMap) Swap(i, j int) {
-	o.order[i], o.order[j] = o.order[j], o.order[i]
-}
-
-
-
-// sortStringByValues is a helper structure so the map can be sorted by value
-type sortStringByValues struct {
-	// This embedded interface permits Reverse to use the methods of
-	// another interface implementation.
-	sort.Interface
-}
-
-// OrderStringSliceMapByValues is a helper function to allow
-// StringSliceMaps to be sorted by values.
-// To sort the map by values, call:
-//   sort.Sort(OrderStringSliceMapByValues(m))
-func OrderStringSliceMapByValues(o *StringSliceMap) sort.Interface {
-	return &sortStringByValues{o}
-}
-
-// A helper function to allow StringSliceMaps to be sorted by values
-func (r sortStringByValues) Less(i, j int) bool {
-	var o *StringSliceMap = r.Interface.(*StringSliceMap)
-
-
-	return o.items[o.order[i]] < o.items[o.order[j]]
-
-}
-
- 
 
 // Copy will make a copy of the map and a copy of the underlying data.
 func (o *StringSliceMap) Copy() *StringSliceMap {
@@ -281,6 +293,8 @@ func (o *StringSliceMap) Copy() *StringSliceMap {
 }
 
 // MarshalBinary implements the BinaryMarshaler interface to convert the map to a byte stream.
+// If you are using a sort function, you must save and restore the sort function in a separate operation
+// since functions are not serializable.
 func (o *StringSliceMap) MarshalBinary() (data []byte, err error) {
 	buf := new(bytes.Buffer)
 	encoder := gob.NewEncoder(buf)

--- a/pkg/maps/strslicemap_test.go
+++ b/pkg/maps/strslicemap_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"sort"
 	"testing"
 )
 
@@ -44,12 +43,6 @@ func TestStringSliceMap(t *testing.T) {
 	if s != "This+That+Other" {
 		t.Error("Failed Join.")
 	}
-
-    // Test that it satisfies the Sort interface
-    sort.Sort(m)
-    if s = m.GetAt(0); s != "That" {
-        t.Error("Sort interface test failed.")
-    }
 
 	m.Delete("A")
 
@@ -117,7 +110,10 @@ func ExampleStringSliceMap_Range() {
 	fmt.Println()
 
 	// Iterate after sorting values
-	sort.Sort(OrderStringSliceMapByValues(m))
+    m.SetSortFunc(func(key1, key2 string, val1, val2 string) bool {
+        return val1 < val2
+    })
+
 	m.Range(func(key string, val string) bool {
 		fmt.Printf("%s:%s,", key, val)
 		return true // keep iterating to the end
@@ -125,7 +121,9 @@ func ExampleStringSliceMap_Range() {
 	fmt.Println()
 
 	// Iterate after sorting keys
-	sort.Sort(m)
+    m.SetSortFunc(func(key1, key2 string, val1, val2 string) bool {
+        return key1 < key2
+    })
 	m.Range(func(key string, val string) bool {
 		fmt.Printf("%s:%s,", key, val)
 		return true // keep iterating to the end
@@ -181,7 +179,7 @@ func ExampleStringSliceMap_UnmarshalJSON() {
 	var m StringSliceMap
 
 	json.Unmarshal(b, &m)
-	sort.Sort(&m)
+	m.SortByKeys()
 
 	fmt.Println(&m)
 
@@ -259,7 +257,7 @@ func TestStringSliceMap_SetAt(t *testing.T) {
 	    t.Errorf("Middle insert failed. Expected C and got %s", m.GetAt(1))
 	}
 
-	m.SetAt(-2, "d", "D")
+	m.SetAt(-1, "d", "D")
     if "D" != m.GetAt(2) {
         t.Errorf("Middle insert failed. Expected D and got %s", m.GetAt(2))
     }
@@ -268,7 +266,7 @@ func TestStringSliceMap_SetAt(t *testing.T) {
     }
 
 	// Test end inserts
-	m.SetAt(-1, "e", "E")
+	m.SetAt(m.Len(), "e", "E")
 	m.SetAt(1000, "f", "F")
     if "E" != m.GetAt(4) {
         t.Errorf("End insert failed. Expected E and got %s", m.GetAt(4))

--- a/templates/map_src/slice_map.tmpl
+++ b/templates/map_src/slice_map.tmpl
@@ -37,8 +37,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"encoding/json"
-{{- if or .valueIsComparer .valueIsComparable}}
-	"sort"{{end}}
+	"sort"
 	"strings"
 {{- if .Safe}}
     "sync"{{end}}
@@ -60,6 +59,7 @@ type {{.Safe}}{{.KeyType}}{{.ValType}}SliceMap struct {
     sync.RWMutex{{end}}
 	items map[{{.keytype}}]{{.valtype}}
 	order []{{.keytype}}
+	lessF func(key1,key2 {{.keytype}}, val1, val2 {{.valtype}}) bool
 }
 
 // New{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap creates a new map that maps {{.keytype}}'s to {{.valtype}}'s.
@@ -90,12 +90,38 @@ func New{{.Safe}}{{.KeyType}}{{.ValType}}SliceMapFromMap(i map[{{.keytype}}]{{.v
 	return m
 }
 
+// SetSortFunc sets the sort function which will determine the order of the items in the map
+// on an ongoing basis. Normally, items will iterate in the order they were added.
+// The sort function is a Less function, that returns true when item 1 is "less" than item 2.
+// The sort function receives both the keys and values, so it can use either to decide how to sort.
+func (o *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap) SetSortFunc(f func(key1,key2 {{.keytype}}, val1, val2 {{.valtype}}) bool) {
+    {{- if .Safe}}
+        o.Lock(){{end}}
+    o.lessF = f
+    if f != nil && len(o.order) > 0 {
+        sort.Slice(o.order, func(i,j int) bool {
+            return f(o.order[i], o.order[j], o.items[o.order[i]], o.items[o.order[j]])
+        })
+    }
+    {{- if .Safe}}
+        o.Unlock(){{end}}
+}
 
+// SortByKeys sets up the map to have its sort order sort by keys, lowest to highest
+func (o *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap) SortByKeys() {
+    o.SetSortFunc(keySort{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap)
+}
 
-// SetChanged sets the value, but also appends the value to the end of the list.
+func keySort{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap(key1, key2 {{.keytype}}, val1, val2 {{.valtype}}) bool {
+    return key1 < key2
+}
+
+// SetChanged sets the value.
 // It returns true if something in the map changed. If the key
-// was already in the map, the order will not change, but the value will be replaced. If you want the
-// order to change, you must Delete then call SetChanged.
+// was already in the map, and you have not provided a sort function,
+// the order will not change, but the value will be replaced. If you wanted the
+// order to change, you must Delete then call SetChanged. If you have previously set a sort function,
+// the order will be updated.
 func (o *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap) SetChanged(key {{.keytype}}, val {{.valtype}}) (changed bool) {
 	var ok bool
 	var oldVal {{.valtype}}
@@ -112,8 +138,25 @@ func (o *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap) SetChanged(key {{.keytype}},
 	}
 
 	if oldVal, ok = o.items[key]; !ok || oldVal != val {
-		if !ok {
-			o.order = append(o.order, key)
+        if o.lessF != nil {
+            if ok {
+                // delete old key location
+                loc := sort.Search (len(o.items), func(n int) bool {
+                    return o.lessF(key, o.order[n], oldVal, o.items[o.order[n]])
+                })
+                o.order = append(o.order[:loc], o.order[loc+1:]...)
+            }
+
+            loc := sort.Search (len(o.items), func(n int) bool {
+                return o.lessF(key, o.order[n], val, o.items[o.order[n]])
+            })
+            o.order = append(o.order, key)
+            copy(o.order[loc+1:], o.order[loc:])
+            o.order[loc] = key
+        } else {
+		    if !ok {
+			    o.order = append(o.order, key)
+		    }
 		}
 		o.items[key] = val
 		changed = true
@@ -132,14 +175,17 @@ func (o *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap) Set(key {{.keytype}}, val {{
 }
 
 // SetAt sets the given key to the given value, but also inserts it at the index specified.  If the index is bigger than
-// the length, or -1, it is the same as Set, in that it puts it at the end. Negative indexes are backwards from the
-// end, if smaller than the negative length, just inserts at the beginning.
+// the length, it puts it at the end. Negative indexes are backwards from the end.
 func (o *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap) SetAt(index int, key {{.keytype}}, val {{.valtype}})  {
     if o == nil {
         panic("You must initialize the map before using it.")
     }
 
-	if index == -1 || index >= len(o.order) {
+    if o.lessF != nil {
+        panic("You cannot use SetAt if you are also using a sort function.")
+    }
+
+	if index >= len(o.order) {
 		o.Set(key, val)
 		return
 	}
@@ -151,11 +197,11 @@ func (o *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap) SetAt(index int, key {{.keyt
     o.Lock(){{end}}
 
 	if _, ok = o.items[key]; !ok {
-		if index < -len(o.items) {
+		if index <= -len(o.items) {
 			index = 0
 		}
 		if index < 0 {
-			index = len(o.items) + index + 1
+			index = len(o.items) + index
 		}
 
 		o.order = append(o.order, emptyKey)
@@ -176,13 +222,24 @@ func (o *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap) Delete(key {{.keytype}}) {
 
 {{- if .Safe}}
     o.Lock(){{end}}
-	for i, v := range o.order {
-		if v == key {
-			o.order = append(o.order[:i], o.order[i+1:]...)
-			break
-		}
-	}
-	delete(o.items, key)
+
+    if _,ok := o.items[key]; ok {
+        if o.lessF != nil {
+            oldVal := o.items[key]
+            loc := sort.Search (len(o.items), func(n int) bool {
+                return o.lessF(key, o.order[n], oldVal, o.items[o.order[n]])
+            })
+            o.order = append(o.order[:loc], o.order[loc+1:]...)
+        } else {
+            for i, v := range o.order {
+                if v == key {
+                    o.order = append(o.order[:i], o.order[i+1:]...)
+                    break
+                }
+            }
+        }
+        delete(o.items, key)
+    }
 {{- if .Safe}}
     o.Unlock(){{end}}
 }
@@ -349,61 +406,6 @@ func (o *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap) Len() int {
 	return l
 }
 
-// Less is part of the interface that allows the map to be sorted by keys.
-// It returns true if the value at position i should be sorted before the value at position j.
-func (o *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap) Less(i, j int) bool {
-{{ if .Safe}}
-	o.RLock()
-	defer o.RUnlock(){{end}}
-{{if .keyIsComparer}}
-    return o.order[i].Compare(o.order[j]) < 0
-{{else}}
-	return o.order[i] < o.order[j]
-{{end}}
-}
-
-// Swap is part of the interface that allows the slice to be sorted. It swaps the positions
-// of the items and position i and j.
-func (o *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap) Swap(i, j int) {
-{{- if .Safe}}
-	o.Lock(){{end}}
-	o.order[i], o.order[j] = o.order[j], o.order[i]
-{{- if .Safe}}
-    o.Unlock(){{end}}
-}
-
-{{if or .valueIsComparer .valueIsComparable}}
-
-// sort{{.Safe}}{{.KeyType}}{{.ValType}}ByValues is a helper structure so the map can be sorted by value
-type sort{{.Safe}}{{.KeyType}}{{.ValType}}ByValues struct {
-	// This embedded interface permits Reverse to use the methods of
-	// another interface implementation.
-	sort.Interface
-}
-
-// Order{{.Safe}}{{.KeyType}}{{.ValType}}SliceMapByValues is a helper function to allow
-// {{.Safe}}{{.KeyType}}{{.ValType}}SliceMaps to be sorted by values.
-// To sort the map by values, call:
-//   sort.Sort(Order{{.Safe}}{{.KeyType}}{{.ValType}}SliceMapByValues(m))
-func Order{{.Safe}}{{.KeyType}}{{.ValType}}SliceMapByValues(o *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap) sort.Interface {
-	return &sort{{.Safe}}{{.KeyType}}{{.ValType}}ByValues{o}
-}
-
-// A helper function to allow {{.Safe}}{{.KeyType}}{{.ValType}}SliceMaps to be sorted by values
-func (r sort{{.Safe}}{{.KeyType}}{{.ValType}}ByValues) Less(i, j int) bool {
-	var o *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap = r.Interface.(*{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap)
-{{- if .Safe}}
-	o.RLock()
-	defer o.RUnlock(){{end}}
-
-{{if .valueIsComparer}}
-    return o.items[o.order[i]].Compare(o.items[o.order[j]]) < 0
-{{else if .valueIsComparable}}
-	return o.items[o.order[i]] < o.items[o.order[j]]
-{{end}}
-}
-
-{{end}} {{/* if or .valueIsComparer .valueIsComparable */}}
 
 // Copy will make a copy of the map and a copy of the underlying data.
 func (o *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap) Copy() *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap {
@@ -423,6 +425,8 @@ func (o *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap) Copy() *{{.Safe}}{{.KeyType}
 }
 
 // MarshalBinary implements the BinaryMarshaler interface to convert the map to a byte stream.
+// If you are using a sort function, you must save and restore the sort function in a separate operation
+// since functions are not serializable.
 func (o *{{.Safe}}{{.KeyType}}{{.ValType}}SliceMap) MarshalBinary() (data []byte, err error) {
 	buf := new(bytes.Buffer)
 	encoder := gob.NewEncoder(buf)

--- a/templates/map_src/string_interface_slice_test.tmpl
+++ b/templates/map_src/string_interface_slice_test.tmpl
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"sort"
 )
 
 func Test{{.MapType}}SliceMap(t *testing.T) {
@@ -106,7 +105,7 @@ func Example{{.MapType}}SliceMap_Range() {
 
 
 	// Iterate after sorting keys
-	sort.Sort(m)
+	m.SortByKeys()
 	m.Range(func(key string, val interface{}) bool {
 		fmt.Printf("%s:%s,", key, val)
 		return true // keep iterating to the end
@@ -161,7 +160,7 @@ func Example{{.MapType}}SliceMap_UnmarshalJSON() {
 	var m {{.MapType}}SliceMap
 
 	json.Unmarshal(b, &m)
-	sort.Sort(&m)
+	m.SortByKeys()
 	fmt.Println(&m)
 
 	// Output: {"A":"That","B":"This","C":"Other"}
@@ -238,7 +237,7 @@ func Test{{.MapType}}SliceMap_SetAt(t *testing.T) {
 	    t.Errorf("Middle insert failed. Expected C and got %s", m.GetAt(1))
 	}
 
-	m.SetAt(-2, "d", "D")
+	m.SetAt(-1, "d", "D")
     if "D" != m.GetAt(2) {
         t.Errorf("Middle insert failed. Expected D and got %s", m.GetAt(2))
     }
@@ -247,7 +246,7 @@ func Test{{.MapType}}SliceMap_SetAt(t *testing.T) {
     }
 
 	// Test end inserts
-	m.SetAt(-1, "e", "E")
+	m.SetAt(m.Len(), "e", "E")
 	m.SetAt(1000, "f", "F")
     if "E" != m.GetAt(4) {
         t.Errorf("End insert failed. Expected E and got %s", m.GetAt(4))

--- a/templates/map_src/string_string_slice_test.tmpl
+++ b/templates/map_src/string_string_slice_test.tmpl
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"sort"
 	"testing"
 )
 
@@ -44,12 +43,6 @@ func Test{{.MapType}}StringSliceMap(t *testing.T) {
 	if s != "This+That+Other" {
 		t.Error("Failed Join.")
 	}
-
-    // Test that it satisfies the Sort interface
-    sort.Sort(m)
-    if s = m.GetAt(0); s != "That" {
-        t.Error("Sort interface test failed.")
-    }
 
 	m.Delete("A")
 
@@ -117,7 +110,10 @@ func Example{{.MapType}}StringSliceMap_Range() {
 	fmt.Println()
 
 	// Iterate after sorting values
-	sort.Sort(Order{{.MapType}}StringSliceMapByValues(m))
+    m.SetSortFunc(func(key1, key2 string, val1, val2 string) bool {
+        return val1 < val2
+    })
+
 	m.Range(func(key string, val string) bool {
 		fmt.Printf("%s:%s,", key, val)
 		return true // keep iterating to the end
@@ -125,7 +121,9 @@ func Example{{.MapType}}StringSliceMap_Range() {
 	fmt.Println()
 
 	// Iterate after sorting keys
-	sort.Sort(m)
+    m.SetSortFunc(func(key1, key2 string, val1, val2 string) bool {
+        return key1 < key2
+    })
 	m.Range(func(key string, val string) bool {
 		fmt.Printf("%s:%s,", key, val)
 		return true // keep iterating to the end
@@ -181,7 +179,7 @@ func Example{{.MapType}}StringSliceMap_UnmarshalJSON() {
 	var m {{.MapType}}StringSliceMap
 
 	json.Unmarshal(b, &m)
-	sort.Sort(&m)
+	m.SortByKeys()
 
 	fmt.Println(&m)
 
@@ -259,7 +257,7 @@ func Test{{.MapType}}StringSliceMap_SetAt(t *testing.T) {
 	    t.Errorf("Middle insert failed. Expected C and got %s", m.GetAt(1))
 	}
 
-	m.SetAt(-2, "d", "D")
+	m.SetAt(-1, "d", "D")
     if "D" != m.GetAt(2) {
         t.Errorf("Middle insert failed. Expected D and got %s", m.GetAt(2))
     }
@@ -268,7 +266,7 @@ func Test{{.MapType}}StringSliceMap_SetAt(t *testing.T) {
     }
 
 	// Test end inserts
-	m.SetAt(-1, "e", "E")
+	m.SetAt(m.Len(), "e", "E")
 	m.SetAt(1000, "f", "F")
     if "E" != m.GetAt(4) {
         t.Errorf("End insert failed. Expected E and got %s", m.GetAt(4))


### PR DESCRIPTION
Can now do on-going sorts. Removes the need for one-time sorts